### PR TITLE
Avoiding textplain passwords

### DIFF
--- a/Bicep Deployment/_modules/aci.bicep
+++ b/Bicep Deployment/_modules/aci.bicep
@@ -1,5 +1,5 @@
 param aciCount int
-param rgLocation string = resourceGroup().location
+param location string = resourceGroup().location
 param prefix string = 'gt'
 param containerImage string
 param acrServerName string
@@ -15,7 +15,7 @@ var acrPassword = acr.listCredentials().passwords[0].value
 
 resource aciList 'Microsoft.ContainerInstance/containerGroups@2021-03-01' = [for i in range(0,aciCount):{
   name: '${prefix}aci-${i}'
-  location: rgLocation
+  location: location
   properties: {
     sku: 'Standard'
     imageRegistryCredentials:[

--- a/Bicep Deployment/_modules/aci.bicep
+++ b/Bicep Deployment/_modules/aci.bicep
@@ -4,9 +4,14 @@ param prefix string = 'gt'
 param containerImage string
 param acrServerName string
 param acrLoginName string
-param acrPassword string
 param appInsightsKey string
 param networkProfileId string
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
+  name: acrLoginName
+}
+
+var acrPassword = acr.listCredentials().passwords[0].value
 
 resource aciList 'Microsoft.ContainerInstance/containerGroups@2021-03-01' = [for i in range(0,aciCount):{
   name: '${prefix}aci-${i}'

--- a/Bicep Deployment/_modules/alerts.bicep
+++ b/Bicep Deployment/_modules/alerts.bicep
@@ -4,7 +4,7 @@ param functionName string
 param functionHttpUrl string
 param healthyThreshold int
 param alertScope array
-param rgLocation string = resourceGroup().location
+param location string = resourceGroup().location
 
 resource actionGroup 'microsoft.insights/actionGroups@2023-01-01'={
   name: '${prefix}-aci-ag'
@@ -56,7 +56,7 @@ resource metricAlerts 'Microsoft.Insights/metricAlerts@2018-03-01' = {
     }
     autoMitigate: true
     targetResourceType: 'Microsoft.Network/applicationGateways'
-    targetResourceRegion: rgLocation
+    targetResourceRegion: location
     actions: [
       {
         actionGroupId: actionGroup.id

--- a/Bicep Deployment/_modules/alerts.bicep
+++ b/Bicep Deployment/_modules/alerts.bicep
@@ -4,8 +4,9 @@ param functionName string
 param functionHttpUrl string
 param healthyThreshold int
 param alertScope array
+param rgLocation string = resourceGroup().location
 
-resource actionGroup 'microsoft.insights/actionGroups@2019-06-01'={
+resource actionGroup 'microsoft.insights/actionGroups@2023-01-01'={
   name: '${prefix}-aci-ag'
   location: 'Global'
   properties:{
@@ -55,7 +56,7 @@ resource metricAlerts 'Microsoft.Insights/metricAlerts@2018-03-01' = {
     }
     autoMitigate: true
     targetResourceType: 'Microsoft.Network/applicationGateways'
-    targetResourceRegion: resourceGroup().location
+    targetResourceRegion: rgLocation
     actions: [
       {
         actionGroupId: actionGroup.id

--- a/Bicep Deployment/_modules/appgw.bicep
+++ b/Bicep Deployment/_modules/appgw.bicep
@@ -7,11 +7,11 @@ param backendPool string = 'bepool'
 param backendHttpSetting string = 'behttp-port-80'
 param httpListener string = 'listener-port-80'
 param aciIPList array
-param rgLocation string = resourceGroup().location
+param location string = resourceGroup().location
 
 resource pip 'Microsoft.Network/publicIPAddresses@2023-04-01' = {
   name: '${prefix}-pip'
-  location: rgLocation
+  location: location
   sku: {
     name: 'Standard'
     tier: 'Regional'
@@ -33,7 +33,7 @@ resource pip 'Microsoft.Network/publicIPAddresses@2023-04-01' = {
 
 resource appgw 'Microsoft.Network/applicationGateways@2023-04-01' = {
   name: appgwName
-  location: rgLocation
+  location: location
   zones: [
     '1'
     '2'

--- a/Bicep Deployment/_modules/containers.bicep
+++ b/Bicep Deployment/_modules/containers.bicep
@@ -1,8 +1,9 @@
 param imageName string = 'hello-world:latest'
+param location string =  resourceGroup().location
 
-resource acr 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {
+resource acr 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' = {
   name: uniqueString(resourceGroup().id)
-  location: resourceGroup().location
+  location: location
   sku:{
     name: 'Basic'
   }
@@ -14,7 +15,7 @@ resource acr 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {
 resource acrBuildImage 'Microsoft.ContainerRegistry/registries/taskRuns@2019-06-01-preview' = {
   parent: acr
   name: 'hellotask'
-  location: resourceGroup().location
+  location: location
   properties: {
     runRequest: {
       type: 'DockerBuildRequest'
@@ -32,7 +33,6 @@ resource acrBuildImage 'Microsoft.ContainerRegistry/registries/taskRuns@2019-06-
   }
 }
 
-output acrPassword string = acr.listCredentials().passwords[0].value
 output acrServerName string = acr.properties.loginServer
 output acrLoginName string = acr.name
 output container_image string = '${acr.properties.loginServer}/${imageName}'

--- a/Bicep Deployment/_modules/cosmosdb.bicep
+++ b/Bicep Deployment/_modules/cosmosdb.bicep
@@ -1,8 +1,8 @@
-param rgLocation string = resourceGroup().location
+param location string = resourceGroup().location
 
 resource cosmosDB 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
   name: uniqueString(resourceGroup().id)
-  location: rgLocation
+  location: location
   kind: 'GlobalDocumentDB'
   properties: {
     publicNetworkAccess: 'Enabled'
@@ -23,9 +23,9 @@ resource cosmosDB 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
     }
     locations: [
       {
-        locationName: rgLocation
+        locationName: location
         failoverPriority: 0
-        isZoneRedundant: false
+        isZoneRedundant: true
       }
     ]
     cors: []

--- a/Bicep Deployment/_modules/cosmosdb.bicep
+++ b/Bicep Deployment/_modules/cosmosdb.bicep
@@ -1,6 +1,8 @@
-resource cosmosDB 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' = {
+param rgLocation string = resourceGroup().location
+
+resource cosmosDB 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
   name: uniqueString(resourceGroup().id)
-  location: resourceGroup().location
+  location: rgLocation
   kind: 'GlobalDocumentDB'
   properties: {
     publicNetworkAccess: 'Enabled'
@@ -21,9 +23,9 @@ resource cosmosDB 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' = {
     }
     locations: [
       {
-        locationName: resourceGroup().location
+        locationName: rgLocation
         failoverPriority: 0
-        isZoneRedundant: true
+        isZoneRedundant: false
       }
     ]
     cors: []

--- a/Bicep Deployment/_modules/functions.bicep
+++ b/Bicep Deployment/_modules/functions.bicep
@@ -1,19 +1,26 @@
 param prefix string
 param sp_client_id string
+@secure()
 param sp_client_secret string
 param appGWName string
 param appInsightInstrumentationKey string
 param acrServerName string
 param acrLoginName string
-param acrPassword string
 param networkProfileName string
 param appgw_bepool_name string
 param appgw_listener_name string
 param appgw_httpsetting_name string
+param location string =  resourceGroup().location
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+resource acr 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' existing = {
+  name: acrLoginName
+}
+
+var acrPassword = acr.listCredentials().passwords[0].value
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   name: uniqueString(resourceGroup().id)
-  location: resourceGroup().location
+  location: location
   kind: 'StorageV2'
   sku: {
     name: 'Standard_LRS'
@@ -21,18 +28,18 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
 }
 
 
-resource functionPlan 'Microsoft.Web/serverfarms@2021-01-15' = {
+resource functionPlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: 'functionPlan'
-  location: resourceGroup().location
+  location: location
   sku:{
     name: 'Y1'
     tier: 'Dynamic'
   }
 }
 
-resource functionApp 'Microsoft.Web/sites@2021-01-15' = {
+resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
   name: '${prefix}-${uniqueString(resourceGroup().id)}'
-  location: resourceGroup().location
+  location: location
   kind: 'functionapp'
   properties:{
     httpsOnly: true
@@ -41,80 +48,80 @@ resource functionApp 'Microsoft.Web/sites@2021-01-15' = {
     siteConfig:{
       appSettings:[
         {
-          'name': 'SP_CLIENT_ID'
-          'value': sp_client_id
+          name: 'SP_CLIENT_ID'
+          value: sp_client_id
         }
         {
-          'name': 'SP_CLIENT_SECRET'
-          'value': sp_client_secret
+          name: 'SP_CLIENT_SECRET'
+          value: sp_client_secret
         }
         {
-          'name': 'TENANT_ID'
-          'value': subscription().tenantId
+          name: 'TENANT_ID'
+          value: subscription().tenantId
         }
         {
-          'name': 'SUBS_ID'
-          'value': subscription().subscriptionId
+          name: 'SUBS_ID'
+          value: subscription().subscriptionId
         }
         {
-          'name': 'RG_NAME'
-          'value': resourceGroup().name
+          name: 'RG_NAME'
+          value: resourceGroup().name
         }
         {
-          'name': 'APPGW_NAME'
-          'value': appGWName
+          name: 'APPGW_NAME'
+          value: appGWName
         }
         {
-          'name': 'APPINSIGHTS_INSTRUMENTATIONKEY'
-          'value': appInsightInstrumentationKey
+          name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
+          value: appInsightInstrumentationKey
         }
         {
-          'name': 'ACR_SERVER_NAME'
-          'value': acrServerName
+          name: 'ACR_SERVER_NAME'
+          value: acrServerName
         }
         {
-          'name': 'ACR_USERNAME'
-          'value': acrLoginName
+          name: 'ACR_USERNAME'
+          value: acrLoginName
         }
         {
-          'name': 'ACR_PW'
-          'value': acrPassword
+          name: 'ACR_PW'
+          value: acrPassword
         }
         {
-          'name': 'NETWORK_PROFILE_NAME'
-          'value': networkProfileName
+          name: 'NETWORK_PROFILE_NAME'
+          value: networkProfileName
         }
         {
-          'name': 'APPGW_BEPOOL_NAME'
-          'value': appgw_bepool_name
+          name: 'APPGW_BEPOOL_NAME'
+          value: appgw_bepool_name
         }
         {
-          'name': 'APPGW_LISTENER_NAME'
-          'value': appgw_listener_name
+          name: 'APPGW_LISTENER_NAME'
+          value: appgw_listener_name
         }
         {
-          'name': 'APPGW_HTTPSETTING_NAME'
-          'value': appgw_httpsetting_name
+          name: 'APPGW_HTTPSETTING_NAME'
+          value: appgw_httpsetting_name
         }
         {
           name: 'AzureWebJobsStorage'
-          value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${listKeys(storageAccount.id, storageAccount.apiVersion).keys[0].value}'
+          value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
         }
         {
-          'name': 'FUNCTIONS_EXTENSION_VERSION'
-          'value': '~3'
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~3'
         }
         {
-          'name': 'FUNCTIONS_WORKER_RUNTIME'
-          'value': 'dotnet'
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'dotnet'
         }
         {
           name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
-          value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${listKeys(storageAccount.id, storageAccount.apiVersion).keys[0].value}'
+          value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
         }
         {
           name: 'WEBSITE_RUN_FROM_PACKAGE'
-          value: 'https://guteemsftshared.blob.core.windows.net/external/Compiled-Functions-Code.zip'
+          value: 'https://guteemsftshared.blob.${environment().suffixes.storage}/external/Compiled-Functions-Code.zip'
         }
       ]
     }

--- a/Bicep Deployment/_modules/monitor.bicep
+++ b/Bicep Deployment/_modules/monitor.bicep
@@ -1,9 +1,9 @@
 param prefix string = 'gt'
-param rgLocation string = resourceGroup().location
+param location string = resourceGroup().location
 
 resource laworkspace 'microsoft.operationalinsights/workspaces@2022-10-01' = {
   name: '${prefix}-app-workspace'
-  location: rgLocation
+  location: location
   properties: {
     sku: {
       name: 'PerGB2018'
@@ -22,7 +22,7 @@ resource laworkspace 'microsoft.operationalinsights/workspaces@2022-10-01' = {
 
 resource appinsight 'microsoft.insights/components@2020-02-02' = {
   name: uniqueString(resourceGroup().id)
-  location: rgLocation
+  location: location
   kind: 'web'
   properties: {
     Application_Type: 'web'

--- a/Bicep Deployment/_modules/monitor.bicep
+++ b/Bicep Deployment/_modules/monitor.bicep
@@ -1,7 +1,7 @@
 param prefix string = 'gt'
 param rgLocation string = resourceGroup().location
 
-resource laworkspace 'microsoft.operationalinsights/workspaces@2021-06-01' = {
+resource laworkspace 'microsoft.operationalinsights/workspaces@2022-10-01' = {
   name: '${prefix}-app-workspace'
   location: rgLocation
   properties: {

--- a/Bicep Deployment/_modules/privatelink.bicep
+++ b/Bicep Deployment/_modules/privatelink.bicep
@@ -2,11 +2,11 @@
 param privateLinkSubnetId string
 param vnetId string
 param cosmosId string
-param rgLocation string = resourceGroup().location
+param location string = resourceGroup().location
 
 resource cosmosPE 'Microsoft.Network/privateEndpoints@2023-04-01' = {
   name: '${uniqueString(resourceGroup().id)}-pe'
-  location: rgLocation
+  location: location
   properties:{
     privateLinkServiceConnections:[
       {

--- a/Bicep Deployment/_modules/privatelink.bicep
+++ b/Bicep Deployment/_modules/privatelink.bicep
@@ -2,10 +2,11 @@
 param privateLinkSubnetId string
 param vnetId string
 param cosmosId string
+param rgLocation string = resourceGroup().location
 
-resource cosmosPE 'Microsoft.Network/privateEndpoints@2021-02-01' = {
+resource cosmosPE 'Microsoft.Network/privateEndpoints@2023-04-01' = {
   name: '${uniqueString(resourceGroup().id)}-pe'
-  location: resourceGroup().location
+  location: rgLocation
   properties:{
     privateLinkServiceConnections:[
       {
@@ -40,7 +41,7 @@ resource privateDNSZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
   }
 }
 
-resource privateDNSZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2021-02-01' = {
+resource privateDNSZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-05-01' = {
   name: '${cosmosPE.name}/cosmosgroup'
   properties:{
     privateDnsZoneConfigs:[

--- a/Bicep Deployment/_modules/vnet.bicep
+++ b/Bicep Deployment/_modules/vnet.bicep
@@ -1,9 +1,9 @@
 param prefix string
-param rgLocation string = resourceGroup().location
+param location string = resourceGroup().location
 
 resource vnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   name: '${prefix}-vnet'
-  location: rgLocation
+  location: location
   properties:{
     addressSpace:{
       addressPrefixes: [
@@ -48,7 +48,7 @@ resource privatelinkSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-04-01
 
 resource aciNetworkProfile 'Microsoft.Network/networkProfiles@2023-04-01' = {
   name: '${aciSubnet.name}-network-profile'
-  location: rgLocation
+  location: location
   properties:{
     containerNetworkInterfaceConfigurations:[
       {

--- a/Bicep Deployment/_modules/vnet.bicep
+++ b/Bicep Deployment/_modules/vnet.bicep
@@ -1,8 +1,9 @@
 param prefix string
+param rgLocation string = resourceGroup().location
 
-resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+resource vnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   name: '${prefix}-vnet'
-  location: resourceGroup().location
+  location: rgLocation
   properties:{
     addressSpace:{
       addressPrefixes: [
@@ -12,7 +13,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' = {
   }
 }
 
-resource appgwSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = {
+resource appgwSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-04-01' = {
   parent: vnet
   name: 'appgw-subnet'
   properties: {
@@ -20,7 +21,7 @@ resource appgwSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = {
   }
 }
 
-resource aciSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = {
+resource aciSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-04-01' = {
   parent: vnet
   name: 'aci-subnet'
   properties: {
@@ -36,7 +37,7 @@ resource aciSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = {
   }
 }
 
-resource privatelinkSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = {
+resource privatelinkSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-04-01' = {
   parent:vnet
   name: 'privatelink-subnet'
   properties: {
@@ -45,9 +46,9 @@ resource privatelinkSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01
   }
 }
 
-resource aciNetworkProfile 'Microsoft.Network/networkProfiles@2021-02-01' = {
+resource aciNetworkProfile 'Microsoft.Network/networkProfiles@2023-04-01' = {
   name: '${aciSubnet.name}-network-profile'
-  location: resourceGroup().location
+  location: rgLocation
   properties:{
     containerNetworkInterfaceConfigurations:[
       {

--- a/Bicep Deployment/main.bicep
+++ b/Bicep Deployment/main.bicep
@@ -18,7 +18,7 @@ module vnet '_modules/vnet.bicep' = {
   scope: rg
   params:{
     prefix: deploy_prefix
-    rgLocation: rg_location
+    location: rg_location
   }
 }
 
@@ -27,7 +27,7 @@ module monitoring '_modules/monitor.bicep' = {
   scope: rg
   params:{
     prefix:deploy_prefix
-    rgLocation: rg_location
+    location: rg_location
   }
 }
 
@@ -50,7 +50,7 @@ module aci '_modules/aci.bicep' = {
     acrServerName: acr.outputs.acrServerName
     acrLoginName: acr.outputs.acrLoginName
     containerImage: acr.outputs.container_image
-    rgLocation: rg_location
+    location: rg_location
   }
 }
 
@@ -61,7 +61,7 @@ module appgw '_modules/appgw.bicep' = {
     prefix: deploy_prefix
     appgwSubnetId: vnet.outputs.appgwSubnet
     aciIPList: aci.outputs.aciAddress
-    rgLocation: rg_location
+    location: rg_location
   }
 }
 
@@ -88,7 +88,7 @@ module cosmos '_modules/cosmosdb.bicep'= {
   name: 'azurecosmosdb'
   scope: rg
   params:{
-    rgLocation: rg_location
+    location: rg_location
   }
 }
 
@@ -99,7 +99,7 @@ module privatelink '_modules/privatelink.bicep'={
     privateLinkSubnetId: vnet.outputs.privatelinkSubnet
     vnetId: vnet.outputs.vnetId
     cosmosId: cosmos.outputs.cosmosId
-    rgLocation: rg_location
+    location: rg_location
   }
 }
 
@@ -113,6 +113,6 @@ module alerts '_modules/alerts.bicep'={
     functionHttpUrl: 'https://${functions.outputs.functionUrl}/api/aci_healing_durable_HttpStart'
     healthyThreshold: aci_count - 1
     alertScope: array(appgw.outputs.appGWId)
-    rgLocation: rg_location
+    location: rg_location
   }
 }

--- a/Bicep Deployment/main.bicep
+++ b/Bicep Deployment/main.bicep
@@ -1,13 +1,14 @@
 param deploy_prefix string
 param rg_name string
 param rg_location string
-param aci_count int
+param aci_count int = 1
 param service_principal_id string
+@secure()
 param service_principal_secret string
 
 targetScope = 'subscription'
 
-resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   name:'${deploy_prefix}-${rg_name}-RG'
   location: rg_location
 }
@@ -17,6 +18,7 @@ module vnet '_modules/vnet.bicep' = {
   scope: rg
   params:{
     prefix: deploy_prefix
+    rgLocation: rg_location
   }
 }
 
@@ -25,12 +27,16 @@ module monitoring '_modules/monitor.bicep' = {
   scope: rg
   params:{
     prefix:deploy_prefix
+    rgLocation: rg_location
   }
 }
 
 module acr '_modules/containers.bicep' = {
   name: 'azurecontainerregistry'
   scope: rg
+  params:{
+    location: rg_location
+  }
 }
 
 module aci '_modules/aci.bicep' = {
@@ -43,8 +49,8 @@ module aci '_modules/aci.bicep' = {
     aciCount: aci_count
     acrServerName: acr.outputs.acrServerName
     acrLoginName: acr.outputs.acrLoginName
-    acrPassword: acr.outputs.acrPassword
     containerImage: acr.outputs.container_image
+    rgLocation: rg_location
   }
 }
 
@@ -55,6 +61,7 @@ module appgw '_modules/appgw.bicep' = {
     prefix: deploy_prefix
     appgwSubnetId: vnet.outputs.appgwSubnet
     aciIPList: aci.outputs.aciAddress
+    rgLocation: rg_location
   }
 }
 
@@ -69,17 +76,20 @@ module functions '_modules/functions.bicep' = {
     appInsightInstrumentationKey: monitoring.outputs.instrumentationKey
     acrServerName: acr.outputs.acrServerName
     acrLoginName: acr.outputs.acrLoginName
-    acrPassword: acr.outputs.acrPassword
     networkProfileName: vnet.outputs.aciNetworkProfileName
     appgw_bepool_name: appgw.outputs.backedPoolName
     appgw_listener_name: appgw.outputs.httpListenerName
     appgw_httpsetting_name: appgw.outputs.backendHttpSetting
+    location: rg_location
   }
 }
 
 module cosmos '_modules/cosmosdb.bicep'= {
   name: 'azurecosmosdb'
   scope: rg
+  params:{
+    rgLocation: rg_location
+  }
 }
 
 module privatelink '_modules/privatelink.bicep'={
@@ -89,6 +99,7 @@ module privatelink '_modules/privatelink.bicep'={
     privateLinkSubnetId: vnet.outputs.privatelinkSubnet
     vnetId: vnet.outputs.vnetId
     cosmosId: cosmos.outputs.cosmosId
+    rgLocation: rg_location
   }
 }
 
@@ -102,5 +113,6 @@ module alerts '_modules/alerts.bicep'={
     functionHttpUrl: 'https://${functions.outputs.functionUrl}/api/aci_healing_durable_HttpStart'
     healthyThreshold: aci_count - 1
     alertScope: array(appgw.outputs.appGWId)
+    rgLocation: rg_location
   }
 }


### PR DESCRIPTION
Reference:
https://learn.microsoft.com/azure/azure-resource-manager/bicep/scenarios-secrets

Outputs are logged to the deployment history, and anyone with access to the deployment can view the values of a deployment's outputs.

When you need to provide secrets to your Bicep deployments as parameters, [use the @secure() decorator](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameters#secure-parameters). When you mark a parameter as secure, Azure Resource Manager avoids logging the value or displaying it in the Azure portal, Azure CLI, or Azure PowerShell.

Extra:
   Update API, removing some bicep warning